### PR TITLE
适配新的 urllib API

### DIFF
--- a/lib/payment.js
+++ b/lib/payment.js
@@ -128,7 +128,7 @@ Payment.prototype.getEditAddressParams = function* getEditAddressParams(data) {
 Payment.prototype._httpRequest = function(url, data){
   return urllib.request(url, {
     method: 'POST',
-    body: data
+    data: data
   });
 };
 
@@ -205,7 +205,7 @@ Payment.prototype._signedQuery = function* _signedQuery(url, params, options){
   var that = this;
 
   var parseString = thunkify(xml2js.parseString);
-  var result = yield parseString(response, {explicitArray: false});
+  var result = yield parseString([response.data, response.headers], {explicitArray: false});
   result = result.xml;
   var err = that.check(result);
   if(err){

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -126,8 +126,7 @@ Payment.prototype.getEditAddressParams = function* getEditAddressParams(data) {
 };
 
 Payment.prototype._httpRequest = function(url, data){
-  return urllib.request({
-    url: url,
+  return urllib.request(url, {
     method: 'POST',
     body: data
   });


### PR DESCRIPTION
## 在 urllib 2.2x 测试下 url 放到 args 下会失效， 导致非 http 的请求失败

```
  console.log(yield urllib.request({url: 'http://www.bilibili.com'}))
会提示 

Unhandled rejection Error: connect ECONNREFUSED 127.0.0.1:80
    at Object.exports._errnoException (util.js:1022:11)
    at exports._exceptionWithHostPort (util.js:1045:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1087:14)


查询订单会提示一样的错误
``` 

## 修改后测试结果
```
yield wxpay.queryOrder({ out_trade_no: 'xx' })

{ return_code: 'SUCCESS',
  return_msg: 'OK',
  ... ...
  result_code: 'SUCCESS',
  trade_state: 'NOTPAY',
  trade_state_desc: '订单未支付' 
```